### PR TITLE
Install additional compiler versions for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,10 @@ jobs:
           submodules: true
 
       - name: Dependencies
-        run: sudo apt install libeigen3-dev
+        run: |
+          sudo apt update
+          sudo apt install g++-7 g++-8 clang-8 clang-9
+          sudo apt install libeigen3-dev
 
       - name: Configure
         run: |


### PR DESCRIPTION
Older compiler versions were removed from the CI images, so an explicit installation is required for GCC 7/8 and Clang 8/9.