### PR TITLE
Only build Python packages on request

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,8 +1,11 @@
 name: CI Python Linux
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -14,25 +17,35 @@ jobs:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
+      - uses: khan/pull-request-comment-trigger@master
+        id: check
+        with:
+          trigger: 'build python'
+
       - name: Checkout
+        if: steps.check.outputs.triggered == 'true'
         uses: actions/checkout@v2
         with:
           submodules: true
 
       - name: Setup Python ${{ matrix.python-version }}
+        if: steps.check.outputs.triggered == 'true'
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Dependencies
+        if: steps.check.outputs.triggered == 'true'
         run: |
           sudo apt install libeigen3-dev
           python -m pip install pytest
 
       - name: Install
+        if: steps.check.outputs.triggered == 'true'
         run: |
           python -m pip install .
 
       - name: Test
+        if: steps.check.outputs.triggered == 'true'
         run: |
           pytest


### PR DESCRIPTION
The Python packages should now be built only when triggered via a special comment 'build python' or in case the action was triggered manually.