### PR TITLE
Explicit dependency on Python 3 and CMake brush-up

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,154 @@
+# -----------------------------
+# Options affecting formatting.
+# -----------------------------
+with section("format"):
+
+  # Disable formatting entirely, making cmake-format a no-op
+  disable = False
+
+  # How wide to allow formatted cmake files
+  line_width = 80
+
+  # How many spaces to tab for indent
+  tab_size = 2
+
+  # If true, lines are indented using tab characters (utf-8 0x09) instead of
+  # <tab_size> space characters (utf-8 0x20). In cases where the layout would
+  # require a fractional tab character, the behavior of the  fractional
+  # indentation is governed by <fractional_tab_policy>
+  use_tabchars = False
+
+  # If <use_tabchars> is True, then the value of this variable indicates how
+  # fractional indentions are handled during whitespace replacement. If set to
+  # 'use-space', fractional indentation is left as spaces (utf-8 0x20). If set
+  # to `round-up` fractional indentation is replaced with a single tab character
+  # (utf-8 0x09) effectively shifting the column to the next tabstop
+  fractional_tab_policy = 'use-space'
+
+  # If an argument group contains more than this many sub-groups (parg or kwarg
+  # groups) then force it to a vertical layout.
+  max_subgroups_hwrap = 2
+
+  # If a positional argument group contains more than this many arguments, then
+  # force it to a vertical layout.
+  max_pargs_hwrap = 6
+
+  # If a cmdline positional group consumes more than this many lines without
+  # nesting, then invalidate the layout (and nest)
+  max_rows_cmdline = 2
+
+  # If true, separate flow control names from their parentheses with a space
+  separate_ctrl_name_with_space = False
+
+  # If true, separate function names from parentheses with a space
+  separate_fn_name_with_space = False
+
+  # If a statement is wrapped to more than one line, than dangle the closing
+  # parenthesis on its own line.
+  dangle_parens = True
+
+  # If the trailing parenthesis must be 'dangled' on its on line, then align it
+  # to this reference: `prefix`: the start of the statement,  `prefix-indent`:
+  # the start of the statement, plus one indentation  level, `child`: align to
+  # the column of the arguments
+  dangle_align = 'prefix'
+
+  # If the statement spelling length (including space and parenthesis) is
+  # smaller than this amount, then force reject nested layouts.
+  min_prefix_chars = 4
+
+  # If the statement spelling length (including space and parenthesis) is larger
+  # than the tab width by more than this amount, then force reject un-nested
+  # layouts.
+  max_prefix_chars = 10
+
+  # If a candidate layout is wrapped horizontally but it exceeds this many
+  # lines, then reject the layout.
+  max_lines_hwrap = 2
+
+  # What style line endings to use in the output.
+  line_ending = 'unix'
+
+  # Format command names consistently as 'lower' or 'upper' case
+  command_case = 'lower'
+
+  # Format keywords consistently as 'lower' or 'upper' case
+  keyword_case = 'unchanged'
+
+  # A list of command names which should always be wrapped
+  always_wrap = []
+
+  # If true, the argument lists which are known to be sortable will be sorted
+  # lexicographicall
+  enable_sort = True
+
+  # If true, the parsers may infer whether or not an argument list is sortable
+  # (without annotation).
+  autosort = False
+
+  # By default, if cmake-format cannot successfully fit everything into the
+  # desired linewidth it will apply the last, most agressive attempt that it
+  # made. If this flag is True, however, cmake-format will print error, exit
+  # with non-zero status code, and write-out nothing
+  require_valid_layout = False
+
+  # A dictionary mapping layout nodes to a list of wrap decisions. See the
+  # documentation for more information.
+  layout_passes = {}
+
+# ----------------------------
+# Options affecting the linter
+# ----------------------------
+with section("lint"):
+
+  # a list of lint codes to disable
+  disabled_codes = []
+
+  # regular expression pattern describing valid function names
+  function_pattern = '[0-9a-z_]+'
+
+  # regular expression pattern describing valid macro names
+  macro_pattern = '[0-9A-Z_]+'
+
+  # regular expression pattern describing valid names for variables with global
+  # (cache) scope
+  global_var_pattern = '[A-Z][0-9A-Z_]+'
+
+  # regular expression pattern describing valid names for variables with global
+  # scope (but internal semantic)
+  internal_var_pattern = '_[A-Z][0-9A-Z_]+'
+
+  # regular expression pattern describing valid names for variables with local
+  # scope
+  local_var_pattern = '[a-z][a-z0-9_]+'
+
+  # regular expression pattern describing valid names for privatedirectory
+  # variables
+  private_var_pattern = '_[0-9a-z_]+'
+
+  # regular expression pattern describing valid names for public directory
+  # variables
+  public_var_pattern = '[A-Z][0-9A-Z_]+'
+
+  # regular expression pattern describing valid names for function/macro
+  # arguments and loop variables.
+  argument_var_pattern = '[a-z][a-z0-9_]+'
+
+  # regular expression pattern describing valid names for keywords used in
+  # functions or macros
+  keyword_pattern = '[A-Z][0-9A-Z_]+'
+
+  # In the heuristic for C0201, how many conditionals to match within a loop in
+  # before considering the loop a parser.
+  max_conditionals_custom_parser = 2
+
+  # Require at least this many newlines between statements
+  min_statement_spacing = 1
+
+  # Require no more than this many newlines between statements
+  max_statement_spacing = 2
+  max_returns = 6
+  max_branches = 12
+  max_arguments = 5
+  max_localvars = 15
+  max_statements = 50

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install
         run: |
-          python -m pip install .
+          python -m pip install -v .
 
       - name: Test
         run: |

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -176,6 +176,7 @@ jobs:
             brew install openblas &&
             export OPENBLAS="$(brew --prefix openblas)" &&
             python -m pip install numpy
+          CIBW_BUILD_VERBOSITY: 1
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: "python -m pytest {project}/test"
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(overlap LANGUAGES CXX)
 
 option(OVERLAP_TESTS "Build the tests" on)
 option(OVERLAP_COVERAGE "Build with coverage support" off)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
+# prefer first detected Python verion to avoid issues with virtual envs
+set(Python_FIND_STRATEGY LOCATION)
 
 # Header-only library.
 include_directories(${PROJECT_SOURCE_DIR})
@@ -17,35 +20,38 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Set up the Eigen3 library.
 find_package(Eigen3 3.2.0 NO_MODULE)
 if(NOT TARGET Eigen3::Eigen)
-    message(STATUS "Failed to find Eigen3 >= 3.2.0, using internal version")
+  message(STATUS "Failed to find Eigen3 >= 3.2.0, using internal version")
 
-    add_library(Eigen3::Eigen IMPORTED INTERFACE)
-    set_property(TARGET Eigen3::Eigen PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                 "${PROJECT_SOURCE_DIR}/third_party/eigen")
+  add_library(Eigen3::Eigen IMPORTED INTERFACE)
+  set_property(
+    TARGET Eigen3::Eigen PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                                  "${PROJECT_SOURCE_DIR}/third_party/eigen"
+  )
 endif()
 
 # Add dummy interface for coverage configuration.
 add_library(coverage INTERFACE)
 
 if(OVERLAP_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "[GNU|Clang]")
-    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-        message(FATAL_ERROR "Generation of coverage information "
-                "requires debug build, set CMAKE_BUILD_TYPE=Debug.")
-    endif()
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(FATAL_ERROR "Generation of coverage information "
+                        "requires debug build, set CMAKE_BUILD_TYPE=Debug."
+    )
+  endif()
 
-    message(STATUS "Enabling generation of coverage reports")
-    target_compile_options(coverage INTERFACE --coverage)
-    target_link_options(coverage INTERFACE --coverage)
+  message(STATUS "Enabling generation of coverage reports")
+  target_compile_options(coverage INTERFACE --coverage)
+  target_link_options(coverage INTERFACE --coverage)
 endif()
 
 # Activate the unit tests.
 if(OVERLAP_TESTS)
-    enable_testing()
-    add_subdirectory(test)
+  enable_testing()
+  add_subdirectory(test)
 endif()
 
 # Build the Python bindings using pybind11.
 option(OVERLAP_PYTHON "Build the Python bindings" ON)
 if(OVERLAP_PYTHON)
-    add_subdirectory(python)
+  add_subdirectory(python)
 endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,13 +1,33 @@
-# Build pybind11 shipped as a third-party dependency.
-add_subdirectory("${PROJECT_SOURCE_DIR}/third_party/pybind11"
-                 "third_party/pybind11"
-                 EXCLUDE_FROM_ALL)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
+  set(python_components Interpreter Development.Module)
+else()
+  set(python_components Interpreter Development)
+endif()
+
+# get FindPython working with scikit-build
+if(SKBUILD)
+  set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+  set(Python_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}")
+  unset(PYTHON_EXECUTABLE)
+  unset(PYTHON_INCLUDE_DIR)
+  unset(PYTHON_LIBRARY)
+  unset(PYTHON_VERSION_STRING)
+endif()
+
+find_package(
+  Python 3.5
+  COMPONENTS ${python_components}
+  REQUIRED
+)
+
+# build pybind11 shipped as a third-party dependency
+add_subdirectory(
+  "${PROJECT_SOURCE_DIR}/third_party/pybind11" "third_party/pybind11"
+  EXCLUDE_FROM_ALL
+)
 
 pybind11_add_module(_overlap MODULE overlap.cpp)
 
 target_link_libraries(_overlap PRIVATE Eigen3::Eigen)
-
-# Forward version info from setup.py.
-#target_compile_definitions(overlap PRIVATE VERSION_INFO=${EXAMPLE_VERSION_INFO})
 
 install(TARGETS _overlap DESTINATION .)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from packaging.version import LegacyVersion
 # available.
 setup_requires = []
 try:
-    if LegacyVersion(cmaker.get_cmake_version()) < LegacyVersion('3.10'):
+    if LegacyVersion(cmaker.get_cmake_version()) < LegacyVersion('3.12'):
         setup_requires.append('cmake')
 except exceptions.SKBuildError:
     setup_requires.append('cmake')
@@ -26,6 +26,7 @@ setup(
     long_description_content_type='text/markdown',
     packages=['overlap'],
     package_dir={'overlap': 'python'},
+    python_requires='>=3.6',
     setup_requires=setup_requires,
     install_requires=[
         'numpy'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,14 +1,26 @@
-# Build GoogleTest shipped as a third-party dependency.
-# Avoid linker issues on Windows when mixing shared and static libraries.
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-add_subdirectory("${PROJECT_SOURCE_DIR}/third_party/googletest"
-                 "third_party/googletest"
-                 EXCLUDE_FROM_ALL)
+# build GoogleTest shipped as a third-party dependency.
+
+# avoid linker issues on Windows when mixing shared and static libraries
+set(gtest_force_shared_crt
+    ON
+    CACHE BOOL "" FORCE
+)
+
+add_subdirectory(
+  "${PROJECT_SOURCE_DIR}/third_party/googletest" "third_party/googletest"
+  EXCLUDE_FROM_ALL
+)
 
 mark_as_advanced(
-    BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS
-    gmock_build_tests gtest_build_samples gtest_build_tests
-    gtest_disable_pthreads gtest_force_shared_crt gtest_hide_internal_symbols
+  BUILD_GMOCK
+  BUILD_GTEST
+  BUILD_SHARED_LIBS
+  gmock_build_tests
+  gtest_build_samples
+  gtest_build_tests
+  gtest_disable_pthreads
+  gtest_force_shared_crt
+  gtest_hide_internal_symbols
 )
 
 set_target_properties(gtest PROPERTIES FOLDER extern)
@@ -16,22 +28,24 @@ set_target_properties(gtest_main PROPERTIES FOLDER extern)
 set_target_properties(gmock PROPERTIES FOLDER extern)
 set_target_properties(gmock_main PROPERTIES FOLDER extern)
 
-# Load GoogleTest module and set up helper function for creating tests.
+# load Google Test module and set up helper function for creating tests
 include(GoogleTest)
 
-macro(overlap_add_test TESTNAME)
-    add_executable(${TESTNAME} ${ARGN})
-    target_link_libraries(${TESTNAME} PRIVATE gtest gtest_main coverage)
+# helper function to dd a test using the Google Test framework
+function(overlap_add_test test_name test_source)
+  add_executable(${test_name} ${test_source})
+  target_link_libraries(${test_name} PRIVATE gtest gtest_main coverage)
 
-    gtest_discover_tests(${TESTNAME}
-        WORKING_DIRECTORY ${PROJECT_DIR}
-        PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}"
-    )
-    set_target_properties(${TESTNAME} PROPERTIES FOLDER test)
-endmacro()
+  gtest_discover_tests(
+    ${test_name}
+    WORKING_DIRECTORY ${PROJECT_DIR}
+    PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}"
+  )
+  set_target_properties(${test_name} PROPERTIES FOLDER test)
+endfunction()
 
-# List of unit tests.
-set(UNIT_TESTS
+# list of unit tests
+set(unit_tests
     decompose_elements
     detail_clamp
     detail_regularizedWedge
@@ -48,8 +62,8 @@ set(UNIT_TESTS
     sphere_tet_overlap_edgecases
 )
 
-# Register the individual unit tests.
-foreach(UNIT_TEST ${UNIT_TESTS})
-    overlap_add_test(${UNIT_TEST} "${UNIT_TEST}.cpp")
-    target_link_libraries(${UNIT_TEST} PUBLIC Eigen3::Eigen)
+# register the individual unit tests
+foreach(unit_test ${unit_tests})
+  overlap_add_test(${unit_test} "${unit_test}.cpp")
+  target_link_libraries(${unit_test} PUBLIC Eigen3::Eigen)
 endforeach()


### PR DESCRIPTION
Instead of eventually failing in `pybind11`, Python 3 support is now explicitly requested, which also means the minimum required CMakeversion is now 3.12.
Also auto-formatted all CMake files using `cmake-format`.