### PR TITLE
Update cibuildwheel to latest version

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Dependencies
         run: |
-          python -m pip install cibuildwheel==1.7.4
+          python -m pip install cibuildwheel
 
       - name: Build wheels
         id: build-wheels


### PR DESCRIPTION
Instead of installing a fixed (potentially outdated) version, just pull the latest one from pip, currently this is 2.2.2.