### PR TITLE
Ensure feenableexcept is available

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,4 +66,8 @@ set(unit_tests
 foreach(unit_test ${unit_tests})
   overlap_add_test(${unit_test} "${unit_test}.cpp")
   target_link_libraries(${unit_test} PUBLIC Eigen3::Eigen)
+
+  if(HAVE_FEENABLEEXCEPT)
+    target_compile_definitions(${unit_test} PRIVATE -DHAVE_FEENABLEEXCEPT)
+  endif()
 endforeach()

--- a/test/sphere_element_area_edgecases.cpp
+++ b/test/sphere_element_area_edgecases.cpp
@@ -24,12 +24,12 @@
 
 #include "common.hpp"
 
-#ifdef _GNU_SOURCE
+#ifdef HAVE_FEENABLEEXCEPT
 #include <fenv.h>
 #endif
 
 TEST(SphereElementAreaTest, EdgeCases) {
-#ifdef _GNU_SOURCE
+#ifdef HAVE_FEENABLEEXCEPT
     feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW | FE_UNDERFLOW);
 #endif
 


### PR DESCRIPTION
Building the project using musl libc fails, as musl does not provide `feenableexcept()`, which seems to be specific to GNU libc on Linux.