### PR TITLE
Fix configure error related to Python components

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-2016]
+        os: [ubuntu-20.04, macos-11, windows-2019]
 
     steps:
       # ref: https://github.com/actions/checkout/issues/331#issuecomment-707103442
@@ -171,7 +171,7 @@ jobs:
       - name: Build wheels
         id: build-wheels
         env:
-          CIBW_SKIP: "cp27-* pp27-* cp35-*"
+          CIBW_SKIP: "cp36-*"
           CIBW_BEFORE_BUILD_MACOS: >
             brew install openblas &&
             export OPENBLAS="$(brew --prefix openblas)" &&

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,17 +1,9 @@
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
+# CMake 3.18 should support this, but there is a bug w.r.t. multiple queries
+# with different components
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
   set(python_components Interpreter Development.Module)
 else()
   set(python_components Interpreter Development)
-endif()
-
-# get FindPython working with scikit-build
-if(SKBUILD)
-  set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  set(Python_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}")
-  unset(PYTHON_EXECUTABLE)
-  unset(PYTHON_INCLUDE_DIR)
-  unset(PYTHON_LIBRARY)
-  unset(PYTHON_VERSION_STRING)
 endif()
 
 find_package(


### PR DESCRIPTION
The explicit handling of the Python variables seems to not be required any more with recent versions of `scikit-build`.