### PR TITLE
Introduce namespace 'overlap'

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ A minimal example calculating the overlap of a hexahedron with a side length of
 hexahedron could look something like this:
 
 ```cpp
+using namespace overlap;
+
 vector_t v0{-1, -1, -1};
 vector_t v1{ 1, -1, -1};
 vector_t v2{ 1,  1, -1};
@@ -92,7 +94,7 @@ vector_t v7{-1,  1,  1};
 Hexahedron hex{v0, v1, v2, v3, v4, v5, v6, v7};
 Sphere s{vector_t::Constant(1), 1};
 
-scalar_t result = overlap(s, hex);
+scalar_t result = overlap_volume(s, hex);
 ```
 
 This code snippet calculates the correct result (&pi;/6) for this simple
@@ -102,6 +104,8 @@ To obtain the overlap area of a sphere and the facets of a tetrahedron, the
 function `overlapArea()` can be employed as such:
 
 ```cpp
+using namespace overlap;
+
 vector_t v0{-std::sqrt(3) / 6.0, -1.0 / 2.0, 0};
 vector_t v1{std::sqrt(3) / 3.0, 0, 0};
 vector_t v2{-std::sqrt(3) / 6.0, +1.0 / 2.0, 0};
@@ -110,7 +114,7 @@ vector_t v3{0, 0, std::sqrt(6) / 3.0};
 Tetrahedron tet{v0, v1, v2, v3};
 Sphere s{{0, 0, 1.5}, 1.25};
 
-auto result = overlapArea(s, tet);
+auto result = overlap_area(s, tet);
 
 std::cout << "surface area of sphere intersecting tetrahedron: " <<
     result[0] << std::endl;
@@ -150,7 +154,7 @@ vertices = np.array((
 tet = overlap.Tetrahedron(vertices)
 sphere = overlap.Sphere((0, 0, 0.5), 1)
 
-result = overlap.overlap(sphere, tet)
+result = overlap.overlap_volume(sphere, tet)
 ```
 
 Calculation of the overlap area instead of the overlap volume is possible via

--- a/python/overlap/overlap.cpp
+++ b/python/overlap/overlap.cpp
@@ -34,6 +34,8 @@ using overload_cast_ = py::detail::overload_cast_impl<Args...>;
 
 using namespace py::literals;
 
+using namespace overlap;
+
 template<typename Element>
 void createBindings(py::module& m) {
   static_assert(std::is_same<Element, Tetrahedron>::value ||
@@ -50,7 +52,8 @@ void createBindings(py::module& m) {
       static_cast<char>(std::tolower(static_cast<char>(name[0]))) +
       name.substr(1);
 
-  static constexpr std::size_t nrVertices = element_trait<Element>::nrVertices;
+  static constexpr std::size_t nrVertices =
+      detail::element_trait<Element>::nrVertices;
 
   py::class_<Element>(m, name.c_str())
       .def(py::init<std::array<vector_t, nrVertices>>())
@@ -80,14 +83,15 @@ void createBindings(py::module& m) {
           [](const Element& elem) { return elem.surfaceArea(); },
           "Return the surface area of the element.");
 
-  m.def("overlap",
-        overload_cast_<const Sphere&, const Element&>()(&overlap<Element>),
-        "sphere"_a, py::arg("nameLower.c_str()"),
-        ("Calculate the overlap volume of a sphere and a " + nameLower + ".")
-            .c_str());
+  m.def(
+      "overlap_volume",
+      overload_cast_<const Sphere&, const Element&>()(&overlap_volume<Element>),
+      "sphere"_a, py::arg("nameLower.c_str()"),
+      ("Calculate the overlap volume of a sphere and a " + nameLower + ".")
+          .c_str());
 
   m.def("overlap_area",
-        overload_cast_<const Sphere&, const Element&>()(&overlapArea<Element>),
+        overload_cast_<const Sphere&, const Element&>()(&overlap_area<Element>),
         "sphere"_a, py::arg("nameLower.c_str()"),
         ("Calculate the overlap area of a sphere and a " + nameLower + ".")
             .c_str());

--- a/tests/python/test_overlap.py
+++ b/tests/python/test_overlap.py
@@ -1,7 +1,7 @@
 # Exact calculation of the overlap volume of spheres and mesh elements.
 # http://dx.doi.org/10.1016/j.jcp.2016.02.003
 
-# Copyright (C) 2021 Severin Strobl <git@severin-strobl.de>
+# Copyright (C) 2021-2022 Severin Strobl <git@severin-strobl.de>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -77,7 +77,8 @@ class TestOverlap:
         wedge = overlap.Wedge(vertices)
         s = overlap.Sphere((1, 1, 1), 1)
 
-        np.testing.assert_almost_equal(overlap.overlap(s, wedge), np.pi / 12)
+        np.testing.assert_almost_equal(
+            overlap.overlap_volume(s, wedge), np.pi / 12)
 
     def test_hexahedron(self):
         vertices = [
@@ -88,7 +89,8 @@ class TestOverlap:
         hexa = overlap.Hexahedron(vertices)
         s = overlap.Sphere((1, 1, 1), 1)
 
-        np.testing.assert_almost_equal(overlap.overlap(s, hexa), np.pi / 6)
+        np.testing.assert_almost_equal(
+            overlap.overlap_volume(s, hexa), np.pi / 6)
 
 
 class TestOverlapArea:

--- a/tests/src/common.hpp
+++ b/tests/src/common.hpp
@@ -27,7 +27,9 @@
 
 #include "overlap/overlap.hpp"
 
-inline Hexahedron unitHexahedron(scalar_t scaling = scalar_t(1)) {
+using namespace overlap;
+
+inline Hexahedron unit_hexahedron(scalar_t scaling = scalar_t(1)) {
   vector_t v0{-1, -1, -1};
   vector_t v1{1, -1, -1};
   vector_t v2{1, 1, -1};
@@ -41,9 +43,9 @@ inline Hexahedron unitHexahedron(scalar_t scaling = scalar_t(1)) {
                     v4 * scaling, v5 * scaling, v6 * scaling, v7 * scaling};
 }
 
-inline void overlap(const Sphere& s, const Hexahedron& hex,
-                    const scalar_t epsilon,
-                    const scalar_t exactResult = scalar_t{-1}) {
+inline void validate_overlap_volume(const Sphere& s, const Hexahedron& hex,
+                                    const scalar_t epsilon,
+                                    const scalar_t exactResult = scalar_t{-1}) {
   std::array<Tetrahedron, 4> subTets;
   std::array<Tetrahedron, 5> tets5;
   std::array<Tetrahedron, 6> tets6;
@@ -53,14 +55,14 @@ inline void overlap(const Sphere& s, const Hexahedron& hex,
   decompose(hex, tets6);
   decompose(hex, wedges);
 
-  const scalar_t overlapCalcHex = overlap(s, hex);
+  const scalar_t overlapCalcHex = overlap_volume(s, hex);
 
   if (exactResult != scalar_t{-1}) {
     ASSERT_NEAR(overlapCalcHex, exactResult, epsilon);
   }
   scalar_t overlapCalcTets5 = 0;
   for (const auto& tet : tets5) {
-    overlapCalcTets5 += overlap(s, tet);
+    overlapCalcTets5 += overlap_volume(s, tet);
   }
 
   scalar_t overlapCalcTets6 = 0;
@@ -69,15 +71,15 @@ inline void overlap(const Sphere& s, const Hexahedron& hex,
     decompose(tet, subTets);
 
     for (const auto& subTet : subTets) {
-      overlapCalcTets24 += overlap(s, subTet);
+      overlapCalcTets24 += overlap_volume(s, subTet);
     }
 
-    overlapCalcTets6 += overlap(s, tet);
+    overlapCalcTets6 += overlap_volume(s, tet);
   }
 
   scalar_t overlapCalcWedges = 0;
   for (const auto& wedge : wedges) {
-    overlapCalcWedges += overlap(s, wedge);
+    overlapCalcWedges += overlap_volume(s, wedge);
   }
 
   std::cout << "volume hex:    " << overlapCalcHex << std::endl;
@@ -95,8 +97,8 @@ inline void overlap(const Sphere& s, const Hexahedron& hex,
   ASSERT_NEAR(overlapCalcTets6, overlapCalcTets24, epsilon);
 }
 
-inline void area(const Sphere& s, const Hexahedron& hex,
-                 const scalar_t epsilon) {
+inline void validate_overlap_area(const Sphere& s, const Hexahedron& hex,
+                                  const scalar_t epsilon) {
   std::array<Tetrahedron, 4> subTets;
   std::array<Tetrahedron, 5> tets5;
   std::array<Tetrahedron, 6> tets6;
@@ -106,7 +108,7 @@ inline void area(const Sphere& s, const Hexahedron& hex,
   decompose(hex, tets6);
   decompose(hex, wedges);
 
-  const scalar_t areaCalcHex = overlapArea(s, hex)[0];
+  const scalar_t areaCalcHex = overlap_area(s, hex)[0];
 
   scalar_t areaCalcWedges = 0;
   scalar_t areaCalcTets5 = 0;
@@ -114,21 +116,21 @@ inline void area(const Sphere& s, const Hexahedron& hex,
   scalar_t areaCalcTets24 = 0;
 
   for (const auto& tet : tets5) {
-    areaCalcTets5 += overlapArea(s, tet)[0];
+    areaCalcTets5 += overlap_area(s, tet)[0];
   }
 
   for (const auto& tet : tets6) {
     decompose(tet, subTets);
 
     for (const auto& subTet : subTets) {
-      areaCalcTets24 += overlapArea(s, subTet)[0];
+      areaCalcTets24 += overlap_area(s, subTet)[0];
     }
 
-    areaCalcTets6 += overlapArea(s, tet)[0];
+    areaCalcTets6 += overlap_area(s, tet)[0];
   }
 
   for (const auto& wedge : wedges) {
-    areaCalcWedges += overlapArea(s, wedge)[0];
+    areaCalcWedges += overlap_area(s, wedge)[0];
   }
 
   std::cout << "sphere center: [" << s.center.transpose()

--- a/tests/src/test_decompose_elements.cpp
+++ b/tests/src/test_decompose_elements.cpp
@@ -24,8 +24,10 @@
 
 #include "common.hpp"
 
+using namespace overlap;
+
 TEST(DecomposeElements, Hexahedron) {
-  Hexahedron hex = unitHexahedron();
+  Hexahedron hex = unit_hexahedron();
 
   std::array<Tetrahedron, 4> subTets;
   std::array<Tetrahedron, 5> tets5;

--- a/tests/src/test_detail_clamp.cpp
+++ b/tests/src/test_detail_clamp.cpp
@@ -24,7 +24,7 @@
 
 // Test clamping of numbers.
 TEST(Clamp, Basic) {
-  using namespace detail;
+  using namespace overlap::detail;
 
   // clang-format off
 	ASSERT_EQ(clamp(-1.1, -1.0, 1.0, 0.25), -1.0);
@@ -37,7 +37,7 @@ TEST(Clamp, Basic) {
 
 // Test error handling of clamping of numbers using invalid inputs.
 TEST(Clamp, Asserts) {
-  using namespace detail;
+  using namespace overlap::detail;
 
   // clang-format off
   ASSERT_DEBUG_DEATH(clamp(0.0,  1.0, -1.0,  0.0), "");

--- a/tests/src/test_detail_regularizedWedge.cpp
+++ b/tests/src/test_detail_regularizedWedge.cpp
@@ -18,82 +18,77 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define _USE_MATH_DEFINES
-
 #include "gtest/gtest.h"
 
 #include "overlap/overlap.hpp"
 
 // Test regularizedWedge using different values of the distance `d`.
 TEST(RegularizedWedge, Distance) {
-  using namespace detail;
+  using namespace overlap::detail;
 
   // special case should return precisely zero
-  ASSERT_EQ(regularizedWedge(1.0, 1.0, 0.25 * M_PI), 0.0);
+  ASSERT_EQ(regularizedWedge(1.0, 1.0, 0.25 * pi), 0.0);
 
   constexpr scalar_t epsilon = 5 * std::numeric_limits<scalar_t>::epsilon();
 
-  ASSERT_NEAR(regularizedWedge(1.0, detail::tinyEpsilon, 0.25 * M_PI),
-              M_PI / 6.0, epsilon);
+  ASSERT_NEAR(regularizedWedge(1.0, tinyEpsilon, 0.25 * pi), pi / 6.0, epsilon);
 
-  ASSERT_NEAR(regularizedWedge(1.0, detail::tinyEpsilon, 0.5 * M_PI),
-              M_PI / 3.0, epsilon);
+  ASSERT_NEAR(regularizedWedge(1.0, tinyEpsilon, 0.5 * pi), pi / 3.0, epsilon);
 }
 
 // Test regularizedWedge using different values of the angle `alpha`.
 TEST(RegularizedWedge, Angle) {
-  using namespace detail;
+  using namespace overlap::detail;
 
   // special case should return precisely zero
   ASSERT_EQ(regularizedWedge(1.0, 0.5, 0.0), 0.0);
 
   constexpr scalar_t epsilon = std::numeric_limits<scalar_t>::epsilon();
 
-  ASSERT_NEAR(regularizedWedge(1.0, 0.5, 0.5 * M_PI), 5.0 * M_PI / 48.0,
-              epsilon);
+  ASSERT_NEAR(regularizedWedge(1.0, 0.5, 0.5 * pi), 5.0 * pi / 48.0, epsilon);
 
   // test using angle of alpha = pi/2
-  constexpr scalar_t alpha = 0.5 * M_PI;
+  const scalar_t alpha = 0.5 * pi;
   constexpr scalar_t delta = std::numeric_limits<scalar_t>::epsilon();
 
   // introduce slight variations to `alpha` and `z`
   ASSERT_NEAR(
-      regularizedWedge(1.0, 0.5, alpha, 0.5 * std::cos(alpha + 0.5 * M_PI)),
+      regularizedWedge(1.0, 0.5, alpha, 0.5 * std::cos(alpha + 0.5 * pi)),
       regularizedWedge(1.0, 0.5, alpha - delta,
-                       0.5 * std::cos(alpha + 0.5 * M_PI - delta)),
+                       0.5 * std::cos(alpha + 0.5 * pi - delta)),
       5 * epsilon);
 
   ASSERT_NEAR(
-      regularizedWedge(1.0, 0.5, alpha, 0.5 * std::cos(alpha + 0.5 * M_PI)),
+      regularizedWedge(1.0, 0.5, alpha, 0.5 * std::cos(alpha + 0.5 * pi)),
       regularizedWedge(1.0, 0.5, alpha + delta,
-                       0.5 * std::cos(alpha + 0.5 * M_PI + delta)),
+                       0.5 * std::cos(alpha + 0.5 * pi + delta)),
       5 * epsilon);
 
   ASSERT_NEAR(
-      regularizedWedge(1.0, 0.5, alpha, -0.5 * std::cos(alpha + 0.5 * M_PI)),
+      regularizedWedge(1.0, 0.5, alpha, -0.5 * std::cos(alpha + 0.5 * pi)),
       regularizedWedge(1.0, 0.5, alpha - delta,
-                       -0.5 * std::cos(alpha + 0.5 * M_PI - delta)),
+                       -0.5 * std::cos(alpha + 0.5 * pi - delta)),
       5 * epsilon);
 
   ASSERT_NEAR(
-      regularizedWedge(1.0, 0.5, alpha, -0.5 * std::cos(alpha + 0.5 * M_PI)),
+      regularizedWedge(1.0, 0.5, alpha, -0.5 * std::cos(alpha + 0.5 * pi)),
       regularizedWedge(1.0, 0.5, alpha + delta,
-                       -0.5 * std::cos(alpha + 0.5 * M_PI + delta)),
+                       -0.5 * std::cos(alpha + 0.5 * pi + delta)),
       5 * epsilon);
 }
 
 // Test regularizedWedge for simple angles and base points very close to the
 // center.
 TEST(RegularizedWedge, NearCenter) {
-  using namespace detail;
+  using namespace overlap::detail;
 
   constexpr scalar_t epsilon = 5 * std::numeric_limits<scalar_t>::epsilon();
 
   ASSERT_NEAR(regularizedWedge(1.0, std::numeric_limits<scalar_t>::epsilon(),
-                               0.25 * M_PI),
-              M_PI / 6.0, epsilon);
+                               0.25 * pi),
+              pi / 6.0, epsilon);
 
-  ASSERT_NEAR(regularizedWedge(1.0, std::numeric_limits<scalar_t>::epsilon(),
-                               0.5 * M_PI),
-              M_PI / 3.0, epsilon);
+  ASSERT_NEAR(
+      regularizedWedge(1.0, std::numeric_limits<scalar_t>::epsilon(), 0.5 * pi),
+      pi / 3.0, epsilon);
 }

--- a/tests/src/test_detail_regularizedWedgeArea.cpp
+++ b/tests/src/test_detail_regularizedWedgeArea.cpp
@@ -27,7 +27,7 @@
 // Test regularizedWedgeArea using different values for the distance of the
 // intersection point from the center of the sphere `z`.
 TEST(RegularizedWedgeArea, Distance) {
-  using namespace detail;
+  using namespace overlap::detail;
 
   // special cases should return precisely zero
   ASSERT_EQ(regularizedWedgeArea(1.0, 1.0, 0.25 * M_PI), 0.0);
@@ -35,16 +35,16 @@ TEST(RegularizedWedgeArea, Distance) {
 
   constexpr scalar_t delta(2e2 * std::numeric_limits<scalar_t>::epsilon());
 
-  ASSERT_NEAR(regularizedWedgeArea(1.0, detail::tinyEpsilon, 0.5 * M_PI), M_PI,
+  ASSERT_NEAR(regularizedWedgeArea(1.0, tinyEpsilon, 0.5 * M_PI), M_PI,
               5 * delta);
 
-  ASSERT_NEAR(regularizedWedgeArea(1.0, -detail::tinyEpsilon, 0.5 * M_PI), M_PI,
+  ASSERT_NEAR(regularizedWedgeArea(1.0, -tinyEpsilon, 0.5 * M_PI), M_PI,
               5 * delta);
 }
 
 // Test regularizedWedgeArea using different values of the angle `alpha`.
 TEST(regularizedWedgeArea, Angle) {
-  using namespace detail;
+  using namespace overlap::detail;
 
   // special cases should return constants values
   ASSERT_EQ(regularizedWedgeArea(1.0, 0.0, 0.0), 0.0);

--- a/tests/src/test_detail_regularizedWedgeArea.cpp
+++ b/tests/src/test_detail_regularizedWedgeArea.cpp
@@ -18,8 +18,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define _USE_MATH_DEFINES
-
 #include "gtest/gtest.h"
 
 #include "overlap/overlap.hpp"
@@ -30,16 +28,14 @@ TEST(RegularizedWedgeArea, Distance) {
   using namespace overlap::detail;
 
   // special cases should return precisely zero
-  ASSERT_EQ(regularizedWedgeArea(1.0, 1.0, 0.25 * M_PI), 0.0);
-  ASSERT_EQ(regularizedWedgeArea(1.0, -1.0, 0.25 * M_PI), 0.0);
+  ASSERT_EQ(regularizedWedgeArea(1.0, 1.0, 0.25 * pi), 0.0);
+  ASSERT_EQ(regularizedWedgeArea(1.0, -1.0, 0.25 * pi), 0.0);
 
   constexpr scalar_t delta(2e2 * std::numeric_limits<scalar_t>::epsilon());
 
-  ASSERT_NEAR(regularizedWedgeArea(1.0, tinyEpsilon, 0.5 * M_PI), M_PI,
-              5 * delta);
+  ASSERT_NEAR(regularizedWedgeArea(1.0, tinyEpsilon, 0.5 * pi), pi, 5 * delta);
 
-  ASSERT_NEAR(regularizedWedgeArea(1.0, -tinyEpsilon, 0.5 * M_PI), M_PI,
-              5 * delta);
+  ASSERT_NEAR(regularizedWedgeArea(1.0, -tinyEpsilon, 0.5 * pi), pi, 5 * delta);
 }
 
 // Test regularizedWedgeArea using different values of the angle `alpha`.
@@ -48,9 +44,9 @@ TEST(regularizedWedgeArea, Angle) {
 
   // special cases should return constants values
   ASSERT_EQ(regularizedWedgeArea(1.0, 0.0, 0.0), 0.0);
-  ASSERT_EQ(regularizedWedgeArea(1.0, 0.0, 0.5 * M_PI), M_PI);
+  ASSERT_EQ(regularizedWedgeArea(1.0, 0.0, 0.5 * pi), pi);
 
-  ASSERT_NEAR(regularizedWedgeArea(1.0, 0.0, 0.75 * M_PI),
-              2 * M_PI - regularizedWedgeArea(1.0, 0.0, 0.25 * M_PI),
+  ASSERT_NEAR(regularizedWedgeArea(1.0, 0.0, 0.75 * pi),
+              2 * pi - regularizedWedgeArea(1.0, 0.0, 0.25 * pi),
               std::numeric_limits<scalar_t>::epsilon());
 }

--- a/tests/src/test_elements.cpp
+++ b/tests/src/test_elements.cpp
@@ -31,12 +31,12 @@ TEST(Wedge, Constructors) {
 
   // clang-format off
   Wedge wedge1{
-		vector_t{-1, -1, -1}, vector_t{1, -1, -1}, vector_t{1, 1, -1},
-		vector_t{-1, -1, 1},  vector_t{1, -1, 1},  vector_t{1, 1, 1}};
+    vector_t{-1, -1, -1}, vector_t{1, -1, -1}, vector_t{1, 1, -1},
+    vector_t{-1, -1, 1},  vector_t{1, -1, 1},  vector_t{1, 1, 1}};
 
-	Wedge wedge2{std::array<vector_t, 6>{{
-		{-1, -1, -1}, {1, -1, -1}, {1,  1, -1},
-		{-1, -1,  1}, {1, -1,  1}, {1,  1,  1}}}};
+  Wedge wedge2{std::array<vector_t, 6>{{
+    {-1, -1, -1}, {1, -1, -1}, {1,  1, -1},
+    {-1, -1,  1}, {1, -1,  1}, {1,  1,  1}}}};
   // clang-format on
 
   constexpr scalar_t eps = std::numeric_limits<scalar_t>::epsilon();
@@ -48,16 +48,16 @@ TEST(Hexahedron, Constructors) {
   using namespace overlap;
 
   // clang-format off
-	Hexahedron hex1{
-		vector_t{-1, -1, -1}, vector_t{1, -1, -1},
-		vector_t{ 1,  1, -1}, vector_t{-1,  1, -1},
+  Hexahedron hex1{
+    vector_t{-1, -1, -1}, vector_t{1, -1, -1},
+    vector_t{ 1,  1, -1}, vector_t{-1,  1, -1},
 
-		vector_t{-1, -1,  1}, vector_t{1, -1,  1},
-		vector_t{ 1,  1,  1}, vector_t{-1,  1,  1}};
+    vector_t{-1, -1,  1}, vector_t{1, -1,  1},
+    vector_t{ 1,  1,  1}, vector_t{-1,  1,  1}};
 
-	Hexahedron hex2{std::array<vector_t, 8>{{
-		{-1, -1, -1}, {1, -1, -1}, {1,  1, -1}, {-1,  1, -1},
-		{-1, -1,  1}, {1, -1,  1}, {1,  1,  1}, {-1,  1,  1}}}};
+  Hexahedron hex2{std::array<vector_t, 8>{{
+    {-1, -1, -1}, {1, -1, -1}, {1,  1, -1}, {-1,  1, -1},
+    {-1, -1,  1}, {1, -1,  1}, {1,  1,  1}, {-1,  1,  1}}}};
   // clang-format on
 
   constexpr scalar_t eps = std::numeric_limits<scalar_t>::epsilon();

--- a/tests/src/test_elements.cpp
+++ b/tests/src/test_elements.cpp
@@ -23,6 +23,8 @@
 #include "overlap/overlap.hpp"
 
 TEST(Wedge, Constructors) {
+  using namespace overlap;
+
   Wedge wedge0{};
 
   ASSERT_EQ(wedge0.volume, 0.0);
@@ -43,6 +45,8 @@ TEST(Wedge, Constructors) {
 }
 
 TEST(Hexahedron, Constructors) {
+  using namespace overlap;
+
   // clang-format off
 	Hexahedron hex1{
 		vector_t{-1, -1, -1}, vector_t{1, -1, -1},

--- a/tests/src/test_normal_newell.cpp
+++ b/tests/src/test_normal_newell.cpp
@@ -23,6 +23,8 @@
 #include "overlap/overlap.hpp"
 
 TEST(NormalNewell, Basic) {
+  using namespace overlap::detail;
+
   const std::array<vector_t, 3> points = {
       {vector_t(-0.8482081444352685, -0.106496132943784, -0.5188463331100054),
        vector_t(-0.8482081363047198, -0.1064961977010221, -0.5188463331100054),
@@ -32,7 +34,7 @@ TEST(NormalNewell, Basic) {
       1.0 / 3.0 *
       std::accumulate(points.begin(), points.end(), vector_t::Zero().eval());
 
-  vector_t normal(detail::normalNewell(points.begin(), points.end(), center));
+  vector_t normal(normalNewell(points.begin(), points.end(), center));
 
   vector_t expected(0.8482081353353663, 0.1064961653160474, 0.5188463413419023);
 
@@ -42,6 +44,8 @@ TEST(NormalNewell, Basic) {
 }
 
 TEST(NormalNewell, Degenerated) {
+  using namespace overlap::detail;
+
   const std::array<vector_t, 3> points = {
       {vector_t(0, 0, 0), vector_t(1, 1, 0), vector_t(0, 0, 0)}};
 
@@ -49,7 +53,7 @@ TEST(NormalNewell, Degenerated) {
       1.0 / points.size() *
       std::accumulate(points.begin(), points.end(), vector_t::Zero().eval());
 
-  vector_t normal(detail::normalNewell(points.begin(), points.end(), center));
+  vector_t normal(normalNewell(points.begin(), points.end(), center));
 
   ASSERT_LE(normal.norm(), std::numeric_limits<scalar_t>::epsilon())
       << "Invalid normal generated: [" << normal.transpose() << "]";

--- a/tests/src/test_polygon.cpp
+++ b/tests/src/test_polygon.cpp
@@ -23,6 +23,8 @@
 #include "overlap/overlap.hpp"
 
 TEST(Polygon, IsPlanar) {
+  using namespace overlap::detail;
+
   Triangle tri{vector_t{0.0, 0.0, 0.0}, vector_t{1.0, 0.0, 0.0},
                vector_t{1.0, 1.0, 0.0}};
 

--- a/tests/src/test_sphere.cpp
+++ b/tests/src/test_sphere.cpp
@@ -18,22 +18,23 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define _USE_MATH_DEFINES
-
 #include "gtest/gtest.h"
 
 #include "overlap/overlap.hpp"
+
+using namespace overlap;
 
 TEST(Sphere, Volume) {
   Sphere s{vector_t::Zero(), 1.0};
 
   constexpr scalar_t eps = std::numeric_limits<scalar_t>::epsilon();
 
-  ASSERT_NEAR(s.volume, 4.0 / 3.0 * M_PI, eps);
+  ASSERT_NEAR(s.volume, 4.0 / 3.0 * detail::pi, eps);
 
   ASSERT_EQ(s.capVolume(-1 * s.radius), 0.0);
   ASSERT_EQ(s.capVolume(0), 0.0);
-  ASSERT_NEAR(s.capVolume(0.5 * s.radius), (M_PI * 0.25 / 3.0) * 2.5, eps);
+  ASSERT_NEAR(s.capVolume(0.5 * s.radius), (detail::pi * 0.25 / 3.0) * 2.5,
+              eps);
   ASSERT_NEAR(s.capVolume(s.radius), 0.5 * s.volume, eps);
   ASSERT_EQ(s.capVolume(2 * s.radius), s.volume);
   ASSERT_EQ(s.capVolume(3 * s.radius), s.volume);
@@ -44,7 +45,7 @@ TEST(Sphere, SurfaceArea) {
 
   constexpr scalar_t eps = std::numeric_limits<scalar_t>::epsilon();
 
-  ASSERT_NEAR(s.surfaceArea(), 4.0 * M_PI, eps);
+  ASSERT_NEAR(s.surfaceArea(), 4.0 * detail::pi, eps);
 
   ASSERT_EQ(s.capSurfaceArea(-1 * s.radius), 0.0);
   ASSERT_EQ(s.capSurfaceArea(0), 0.0);
@@ -60,7 +61,7 @@ TEST(Sphere, DiskArea) {
 
   ASSERT_EQ(s.diskArea(-1 * s.radius), 0.0);
   ASSERT_EQ(s.diskArea(0), 0.0);
-  ASSERT_NEAR(s.diskArea(s.radius), M_PI, eps);
+  ASSERT_NEAR(s.diskArea(s.radius), detail::pi, eps);
   ASSERT_EQ(s.diskArea(2 * s.radius), 0.0);
   ASSERT_EQ(s.diskArea(3 * s.radius), 0.0);
 }

--- a/tests/src/test_sphere_element_area_edgecases.cpp
+++ b/tests/src/test_sphere_element_area_edgecases.cpp
@@ -61,6 +61,7 @@ TEST(SphereElementAreaTest, EdgeCases) {
 
   const scalar_t epsilon = std::sqrt(std::numeric_limits<scalar_t>::epsilon());
 
-  for (const Sphere& sphere : spheres)
-    area(sphere, unitHexahedron(), epsilon * sphere.volume);
+  for (const Sphere& sphere : spheres) {
+    validate_overlap_area(sphere, unit_hexahedron(), epsilon * sphere.volume);
+  }
 }

--- a/tests/src/test_sphere_element_overlap.cpp
+++ b/tests/src/test_sphere_element_overlap.cpp
@@ -31,33 +31,33 @@ static const scalar_t epsilon =
 TEST(SphereElementOverlap, Face) {
   Sphere s(vector_t{0, 2, 0}, 1);
 
-  overlap(s, unitHexahedron(), epsilon, scalar_t{0});
+  validate_overlap_volume(s, unit_hexahedron(), epsilon, scalar_t{0});
 }
 
 // Sphere intersects one edge (and thus 2 faces).
 TEST(SphereElementOverlap, Edge) {
   Sphere s(vector_t{0, -1, 1}, 1);
 
-  overlap(s, unitHexahedron(), epsilon, 0.25 * s.volume);
+  validate_overlap_volume(s, unit_hexahedron(), epsilon, 0.25 * s.volume);
 }
 
 // Sphere intersects one vertex (and thus 3 edges and 3 faces)
 TEST(SphereElementOverlap, Vertex) {
   Sphere s(vector_t{1, -1, 1}, 1);
 
-  overlap(s, unitHexahedron(), epsilon, 0.125 * s.volume);
+  validate_overlap_volume(s, unit_hexahedron(), epsilon, 0.125 * s.volume);
 }
 
 // Sphere outside of hexahedron, touching one vertex.
 TEST(SphereElementOverlap, VertexTouching) {
   Sphere s(vector_t{2, -1, 1}, 1);
 
-  overlap(s, unitHexahedron(), epsilon, scalar_t{0});
+  validate_overlap_volume(s, unit_hexahedron(), epsilon, scalar_t{0});
 }
 
 // Sphere outside of hexahedron, slightly overlapping one vertex.
 TEST(SphereElementOverlap, Vertex2) {
   Sphere s(vector_t{2 - 10 * detail::tinyEpsilon, -1, 1}, 1);
 
-  overlap(s, unitHexahedron(), epsilon, scalar_t{0});
+  validate_overlap_volume(s, unit_hexahedron(), epsilon, scalar_t{0});
 }

--- a/tests/src/test_sphere_element_overlap_edgecases.cpp
+++ b/tests/src/test_sphere_element_overlap_edgecases.cpp
@@ -53,6 +53,7 @@ TEST(SphereElementOverlapTest, EdgeCases) {
 
   const scalar_t epsilon = std::sqrt(std::numeric_limits<scalar_t>::epsilon());
 
-  for (const Sphere& sphere : spheres)
-    overlap(sphere, unitHexahedron(), epsilon * sphere.volume);
+  for (const Sphere& sphere : spheres) {
+    validate_overlap_volume(sphere, unit_hexahedron(), epsilon * sphere.volume);
+  }
 }

--- a/tests/src/test_sphere_hex_area.cpp
+++ b/tests/src/test_sphere_hex_area.cpp
@@ -26,10 +26,10 @@
 
 // Sphere intersects one face.
 TEST(SphereHexAreaTest, Face) {
-  Hexahedron hex = unitHexahedron();
+  Hexahedron hex = unit_hexahedron();
   Sphere s({0, 0, 1}, 0.75);
 
-  auto result = overlapArea(s, hex);
+  auto result = overlap_area(s, hex);
 
   std::array<scalar_t, 8> resultExact;
   resultExact.fill(scalar_t(0));
@@ -44,10 +44,10 @@ TEST(SphereHexAreaTest, Face) {
 
 // Sphere intersects one edge (and thus 1 edge and 2 faces).
 TEST(SphereHexAreaTest, Edge) {
-  Hexahedron hex = unitHexahedron();
+  Hexahedron hex = unit_hexahedron();
   Sphere s({1, 1, 0}, 0.75);
 
-  auto result = overlapArea(s, hex);
+  auto result = overlap_area(s, hex);
 
   std::array<scalar_t, 8> resultExact;
   resultExact.fill(scalar_t(0));
@@ -63,10 +63,10 @@ TEST(SphereHexAreaTest, Edge) {
 
 // Sphere intersects one vertex (and thus 3 edge and 3 faces).
 TEST(SphereHexAreaTest, Vertex) {
-  Hexahedron hex = unitHexahedron();
+  Hexahedron hex = unit_hexahedron();
   Sphere s({1, 1, 1}, 0.75);
 
-  auto result = overlapArea(s, hex);
+  auto result = overlap_area(s, hex);
 
   std::array<scalar_t, 8> resultExact;
   resultExact.fill(scalar_t(0));

--- a/tests/src/test_sphere_tet_area.cpp
+++ b/tests/src/test_sphere_tet_area.cpp
@@ -36,7 +36,7 @@ TEST(SphereTetAreaTest, SphereInTet) {
   Tetrahedron tet{v0, v1, v2, v3};
   Sphere s({0, 0, 0.25}, 0.125);
 
-  auto result = overlapArea(s, tet);
+  auto result = overlap_area(s, tet);
 
   std::array<scalar_t, 6> resultExact;
   resultExact.fill(scalar_t(0));
@@ -57,7 +57,7 @@ TEST(SphereTetAreaTest, TetInSphere) {
   Tetrahedron tet{v0, v1, v2, v3};
   Sphere s({0, 0, std::sqrt(6) / 6.0}, 2);
 
-  auto result = overlapArea(s, tet);
+  auto result = overlap_area(s, tet);
 
   std::array<scalar_t, 6> resultExact;
   resultExact[0] = scalar_t(0);
@@ -83,7 +83,7 @@ TEST(SphereTetAreaTest, Face) {
   Tetrahedron tet{v0, v1, v2, v3};
   Sphere s({0, 0, 0}, 0.25);
 
-  auto result = overlapArea(s, tet);
+  auto result = overlap_area(s, tet);
 
   std::array<scalar_t, 6> resultExact;
   resultExact.fill(scalar_t(0));
@@ -107,7 +107,7 @@ TEST(SphereTetAreaTest, Vertex) {
   Tetrahedron tet{v0, v1, v2, v3};
   Sphere s({0, 0, 1.5}, 1.25);
 
-  auto result = overlapArea(s, tet);
+  auto result = overlap_area(s, tet);
 
   // Compare with approximate result obtained via an Monte Carlo approach.
   std::array<scalar_t, 6> resultApprox;

--- a/tests/src/test_sphere_tet_overlap_edgecases.cpp
+++ b/tests/src/test_sphere_tet_overlap_edgecases.cpp
@@ -25,6 +25,8 @@
 #include "common.hpp"
 
 TEST(SphereTetOverlap, EdgeCases) {
+  using namespace overlap;
+
   // clang-format off
 	const std::vector<Sphere> spheres = {
 		{vector_t::Zero(), 1.0},
@@ -62,11 +64,12 @@ TEST(SphereTetOverlap, EdgeCases) {
     std::array<Tetrahedron, 4> tets4;
     decompose(tetrahedra[idx], tets4);
 
-    const scalar_t overlapCalcTet = overlap(spheres[idx], tetrahedra[idx]);
+    const scalar_t overlapCalcTet =
+        overlap_volume(spheres[idx], tetrahedra[idx]);
 
     scalar_t overlapCalcTets4 = 0;
     for (const auto& tet : tets4) {
-      overlapCalcTets4 += overlap(spheres[idx], tet);
+      overlapCalcTets4 += overlap_volume(spheres[idx], tet);
     }
 
     std::cout << "volume tet:  " << overlapCalcTet << std::endl;


### PR DESCRIPTION
The library now uses a dedicated namespace `overlap` to avoid potential name conflicts when including the library in other projects. Only the types and methods forming the public API are exposed in this namespace, everything else is contained in the namespace `overlap::detail`.

Also, the free functions to calculate the overlap volume and areas are renamed to `overlap_volume` and `overlap_area`, respectively.