### PR TITLE
Support packaging>=22.0 (python build dependency)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from skbuild import setup, exceptions, cmaker
-from packaging.version import LegacyVersion
+from packaging.version import Version
 
 # Add CMake as a build requirement if no or only an outdated version is
 # available.
 setup_requires = []
 try:
-    if LegacyVersion(cmaker.get_cmake_version()) < LegacyVersion('3.10'):
+    if Version(cmaker.get_cmake_version()) < Version('3.10'):
         setup_requires.append('cmake')
 except exceptions.SKBuildError:
     setup_requires.append('cmake')


### PR DESCRIPTION
Currently, attempting to install the python bindings fails with the following error message:
```
$ pip install overlap
Collecting overlap
  Using cached overlap-0.1.0.tar.gz (3.8 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      Traceback (most recent call last):
        File "/home/kale/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/kale/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/kale/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-d6cjnelc/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-d6cjnelc/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-d6cjnelc/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 338, in run_setup
          exec(code, locals())
        File "<string>", line 2, in <module>
      ImportError: cannot import name 'LegacyVersion' from 'packaging.version' (/tmp/pip-build-env-d6cjnelc/overlay/lib/python3.10/site-packages/packaging/version.py)
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```
The error is due to the fact that `setup.py` imports `packaging.version.LegacyVersion`, which was removed in `packaging=22.0`.  Here's the relevant [changelog entry](https://github.com/pypa/packaging/blob/main/CHANGELOG.rst#220---2022-12-07), and here's the [PR where this was discussed](https://github.com/pypa/packaging/issues/530).

This PR simply replaces `packaging.version.LegacyVersion` with `packaging.version.Version`.  The former was only being used to compare if one version number is less than another, and the latter is capable of making that same comparison.  My understanding is that the only difference between the two classes is that the legacy one doesn't complain if it gets a version number that it doesn't understand (possibly leading to bugs—hence the removal), but in this case both version numbers have normal formats.
