### PR TITLE
Integration of basic C++ benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,121 @@
+name: Trigger and compare benchmarks
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  DEFAULT_REFERENCE_VERSION: develop
+
+jobs:
+  benchmark:
+    name: Benchmark current version
+    uses: ./.github/workflows/run_benchmarks.yml
+    with:
+      ref: ${{ github.sha }}
+
+  check_reference:
+    name: Check for reference benchmark results
+    runs-on: ubuntu-latest
+    steps:
+      - name: Obtain SHA of reference version
+        id: obtain_ref
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            reference_sha="${{ github.event.pull_request.base.sha }}"
+          else
+            reference_sha=$(git rev-parse origin/$DEFAULT_REFERENCE_VERSION)
+          fi
+
+          echo "reference_sha=${reference_sha}" >> $GITHUB_OUTPUT
+
+      - name: Check if benchmark results for reference version exist
+        id:  check_ref_results
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const ref = "${{ steps.obtain_ref.outputs.reference_sha }}";
+            const artifact_name = "benchmarks-" + ref;
+            const artifacts = await github.rest.actions.listArtifactsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: artifact_name,
+            });
+
+            if (artifacts.data.total_count) {
+              console.log(`Benchmark results for revision '${ref}' exist.`);
+            } else {
+              console.log(`Benchmark results for revision '${ref}' do not exist, requesting run.`);
+            }
+
+            return artifacts.data.total_count != 0
+
+    outputs:
+      reference_sha: ${{ steps.obtain_ref.outputs.reference_sha }}
+      reference_results_available: ${{ steps.check_ref_results.outputs.result }}
+
+  benchmark_reference:
+    name: Benchmark reference version
+    needs: check_reference
+    if: ${{ needs.check_reference.outputs.reference_results_available }}
+    uses: ./.github/workflows/run_benchmarks.yml
+    with:
+      ref: ${{ needs.check_reference.outputs.reference_sha }}
+      allow_failure: true
+
+  compare_benchmarks:
+    name: Compare benchmark results
+    needs: [benchmark, benchmark_reference, check_reference]
+    if: ${{ needs.benchmark_reference.outputs.outcome == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependencies
+        run: |
+          python -m pip install pyperf
+          npm install fs
+
+      - name: Obtain benchmark results for reference version
+        uses: actions/download-artifact@v3
+        with:
+          name: benchmarks-${{ needs.check_reference.outputs.reference_sha }}
+          path: ${{ needs.check_reference.outputs.reference_sha }}
+
+      - name: Obtain benchmark results for current version
+        uses: actions/download-artifact@v3
+        with:
+          name: benchmarks-${{ github.sha }}
+          path: ${{ github.sha }}
+
+      - name: Compare benchmark results
+        run: |
+          mv ${{ needs.check_reference.outputs.reference_sha }}/benchmarks.json Reference
+          mv ${{ github.sha }}/benchmarks.json Current
+          python -m pyperf compare_to --table --table-format md Current Reference > report.md
+
+      - name: Create PR comment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs')
+            const msg = '## C++ benchmark results\n# + fs.readFileSync('./report.md')
+            try {
+              const result = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: msg,
+              })
+              return result.data
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`)
+            }
+
+      - name: Report via annotation
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs')
+            core.notice('## C++ benchmark results\n# + fs.readFileSync('./report.md'))

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -1,0 +1,65 @@
+name: Run benchmarks
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA1 hash to benchmark"
+        required: true
+        type: string
+      allow_failure:
+        description: "Allow workflow to continue on failure"
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      outcome:
+        description: "Outcome of the actual benchmarking job"
+        value: ${{ jobs.benchmark.outputs.outcome }}
+
+jobs:
+  benchmark:
+    name: C++ benchmarks
+    runs-on: ubuntu-latest
+    outputs:
+      outcome: ${{ steps.benchmark_step.outcome }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: true
+
+      - name: Dependencies
+        run: |
+          python -m pip install pyperf
+
+      - name: Build and run benchmark for selected revision
+        id: benchmark_step
+        continue-on-error: ${{ inputs.allow_failure }}
+        run: |
+          cmake \
+            -Bbuild \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DOVERLAP_WITH_BENCHMARKS=ON \
+            -DOVERLAP_WITH_TESTS=OFF
+
+          cmake --build build
+
+          ctest --test-dir build -L benchmark
+
+          results=(`ls build/benchmarks/*.json`)
+          cp "${results[0]}" benchmarks.json
+
+          for f in "${results[@]:1}"; do
+            python -m pyperf convert --stdout --add=$f benchmarks.json | jq > combined.json
+            mv combined.json benchmarks.json
+          done
+
+          echo "ref_sha=$(git rev-parse ${{ inputs.ref }})" >> $GITHUB_OUTPUT
+
+      - name: Store benchmark results for selected revision
+        if: ${{ steps.benchmark_step.outcome == 'success' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchmarks-${{ steps.benchmark_step.outputs.ref_sha }}
+          path: benchmarks.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third_party/doctest"]
 	path = third_party/doctest
 	url = https://github.com/doctest/doctest.git
+[submodule "third_party/nanobench"]
+	path = third_party/nanobench
+	url = https://github.com/martinus/nanobench.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ enable_language(CXX)
 
 option(OVERLAP_WITH_PYTHON "Build the Python bindings" on)
 option(OVERLAP_WITH_TESTS "Build the tests" on)
+option(OVERLAP_WITH_BENCHMARKS "Build the benchmarks" off)
 option(OVERLAP_WITH_COVERAGE "Build with coverage support for tests" off)
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
@@ -53,6 +54,13 @@ if(OVERLAP_WITH_TESTS)
   enable_testing()
   add_subdirectory(tests/src)
 endif()
+
+# optional: C++ benchmarks
+if(OVERLAP_WITH_BENCHMARKS)
+  enable_testing()
+  add_subdirectory(benchmarks)
+endif()
+
 
 # optional: build the Python bindings using pybind11
 if(OVERLAP_WITH_PYTHON)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,35 @@
+if(NOT TARGET doctest::doctest)
+  add_subdirectory(
+    "${PROJECT_SOURCE_DIR}/third_party/doctest" "third_party/doctest"
+    EXCLUDE_FROM_ALL
+  )
+
+  list(APPEND CMAKE_MODULE_PATH
+       "${PROJECT_SOURCE_DIR}/third_party/doctest/scripts/cmake"
+  )
+endif()
+
+add_subdirectory(
+  "${PROJECT_SOURCE_DIR}/third_party/nanobench" "third_party/nanobench"
+  EXCLUDE_FROM_ALL
+)
+
+# list of benchmarks
+set(benchmarks details hex_overlap)
+
+# register the individual benchmarks
+foreach(benchmark ${benchmarks})
+  add_executable(${benchmark} ${benchmark}.cpp)
+  target_link_libraries(
+    ${benchmark} PRIVATE overlap::headers Eigen3::Eigen nanobench
+                         doctest::doctest
+  )
+
+  target_compile_definitions(
+    ${benchmark} PRIVATE DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+  )
+
+  add_test(NAME ${benchmark} COMMAND $<TARGET_FILE:${benchmark}>)
+
+  set_tests_properties(${benchmark} PROPERTIES LABELS benchmark)
+endforeach()

--- a/benchmarks/details.cpp
+++ b/benchmarks/details.cpp
@@ -1,0 +1,67 @@
+/*!
+ * Exact calculation of the overlap volume of spheres and mesh elements.
+ * http://dx.doi.org/10.1016/j.jcp.2016.02.003
+ *
+ * Copyright (C) 2022 Severin Strobl <severin.strobl@fau.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <doctest/doctest.h>
+#include <nanobench.h>
+
+#include "overlap/overlap.hpp"
+
+TEST_CASE("NormalNewell") {
+  using namespace overlap::detail;
+
+  const auto points = std::array<Vector, 3>{
+      {{-0.8482081444352685, -0.106496132943784, -0.5188463331100054},
+       {-0.8482081363047198, -0.1064961977010221, -0.5188463331100054},
+       {-0.8482081363047198, -0.106496132943784, -0.5188463464017972}}};
+
+  const auto center =
+      (Scalar{1} / Scalar{3}) *
+      std::accumulate(points.begin(), points.end(), Vector::Zero().eval());
+
+  auto log = std::ofstream{"normal_newell.json"};
+  ankerl::nanobench::Bench()
+      .title("normal_newell")
+      .run("normal_newell",
+           [&]() {
+             const auto normal =
+                 normal_newell(points.begin(), points.end(), center);
+             ankerl::nanobench::doNotOptimizeAway(normal);
+           })
+      .render(ankerl::nanobench::templates::pyperf(), log);
+}
+
+TEST_CASE("RegularizedWedge") {
+  using namespace overlap::detail;
+
+  auto log = std::ofstream{"regularized_wedge.json"};
+  auto rng = ankerl::nanobench::Rng{};
+  ankerl::nanobench::Bench()
+      .title("regularized_wedge")
+      .run("regularized_wedge",
+           [&]() {
+             const auto result = regularized_wedge(1.0, rng.uniform01(),
+                                                   rng.uniform01() * 0.5 * pi);
+
+             ankerl::nanobench::doNotOptimizeAway(result);
+           })
+      .doNotOptimizeAway(rng)
+      .render(ankerl::nanobench::templates::pyperf(), log);
+  ;
+}

--- a/benchmarks/hex_overlap.cpp
+++ b/benchmarks/hex_overlap.cpp
@@ -1,0 +1,74 @@
+/*!
+ * Exact calculation of the overlap volume of spheres and mesh elements.
+ * http://dx.doi.org/10.1016/j.jcp.2016.02.003
+ *
+ * Copyright (C) 2022 Severin Strobl <severin.strobl@fau.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <doctest/doctest.h>
+#include <nanobench.h>
+
+#include "overlap/overlap.hpp"
+
+TEST_CASE("HexOverlapVolume") {
+  using namespace overlap;
+
+  const auto sphere = Sphere{Vector::Zero(), 1};
+
+  // clang-format off
+  const auto hex = Hexahedron{{{
+    {0, 0, -1}, {2, 2, -1},
+    {2, 4, -1}, {0, 4, -1},
+
+    {0, 0, 1}, {2, 2, 1},
+    {2, 4, 1}, {0, 4, 1}}}};
+  // clang-format on
+
+  auto log = std::ofstream{"hex_overlap_volume.json"};
+  ankerl::nanobench::Bench()
+      .title("hex_overlap_volume")
+      .run("hex_overlap_volume",
+           [&]() {
+             const auto result = overlap_volume(sphere, hex);
+             ankerl::nanobench::doNotOptimizeAway(result);
+           })
+      .render(ankerl::nanobench::templates::pyperf(), log);
+}
+
+TEST_CASE("HexOverlapVolumeAABB") {
+  using namespace overlap;
+
+  const auto sphere = Sphere{Vector::Zero(), 1};
+
+  // clang-format off
+  const auto hex = Hexahedron{{{
+    {2, 0, 0}, {4, 0, 0},
+    {4, 2, 0}, {2, 2, 0},
+
+    {2, 0, 2}, {4, 0, 2},
+    {4, 2, 2}, {2, 2, 2}}}};
+  // clang-format on
+
+  auto log = std::ofstream{"hex_overlap_volume_aabb.json"};
+  ankerl::nanobench::Bench()
+      .title("hex_overlap_volume_aabb")
+      .run("hex_overlap_volume_aabb",
+           [&]() {
+             const auto result = overlap_volume(sphere, hex);
+             ankerl::nanobench::doNotOptimizeAway(result);
+           })
+      .render(ankerl::nanobench::templates::pyperf(), log);
+}


### PR DESCRIPTION
Added some simple benchmarks, two for the overall performance, one for `normal_newell` and `regularized_wedge`, respectively. The benchmarks are also triggered via a dedicated CI job when opening pull requests, hopefully allowing to easily spot deteriorating performance.