### PR TITLE
Unify polygon implementation in base class

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -75,7 +75,8 @@ jobs:
         run: |
           python -m pip install pyperf
 
-      - name: Obtain benchmark results for reference version
+      - name: Obtain archived benchmark results for reference version
+        if: ${{ fromJSON(needs.check_reference.outputs.reference_results_available) }}
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -95,6 +96,13 @@ jobs:
 
             fs.writeFileSync(artifact_name, Buffer.from(request.data));
             child_process.execSync(`unzip -o ${artifact_name} -d ${ref}`);
+
+      - name: Obtain new benchmark results for reference version
+        if: ${{ !fromJSON(needs.check_reference.outputs.reference_results_available) }}
+        uses: actions/download-artifact@v3
+        with:
+          name: benchmarks-${{ needs.check_reference.outputs.reference_sha }}
+          path: ${{ needs.check_reference.outputs.reference_sha }}
 
       - name: Obtain benchmark results for current version
         uses: actions/download-artifact@v3


### PR DESCRIPTION
With `if constepxr` provided by C++17 there is no need to push the calculation of the polygon area down to the derived classes. In fact, the derived classes can now simply be type aliases for the generic polygon class.