### PR TITLE
chore: benchmarks for tet overlap

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -15,7 +15,7 @@ add_subdirectory(
 )
 
 # list of benchmarks
-set(benchmarks details hex_overlap)
+set(benchmarks details hex_overlap tet_overlap)
 
 # register the individual benchmarks
 foreach(benchmark ${benchmarks})

--- a/benchmarks/common.hpp
+++ b/benchmarks/common.hpp
@@ -1,0 +1,37 @@
+/*!
+ * Exact calculation of the overlap volume of spheres and mesh elements.
+ * http://dx.doi.org/10.1016/j.jcp.2016.02.003
+ *
+ * Copyright (C) 2023 Severin Strobl <severin.strobl@fau.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <utility>
+
+#include <nanobench.h>
+
+template<typename F>
+inline auto create_benchmark(const std::string& name, F&& func)
+    -> ankerl::nanobench::Bench {
+  auto log = std::ofstream{name + ".json"};
+  return ankerl::nanobench::Bench()
+      .title(name)
+      .minEpochIterations(25000)
+      .run(name, std::forward<F>(func))
+      .render(ankerl::nanobench::templates::pyperf(), log);
+}

--- a/benchmarks/details.cpp
+++ b/benchmarks/details.cpp
@@ -46,7 +46,7 @@ TEST_CASE("RegularizedWedge") {
   using namespace overlap::detail;
 
   auto rng = ankerl::nanobench::Rng{};
-  create_benchmark("normal_newell", [&]() {
+  create_benchmark("regularized_wedge", [&]() {
     const auto result =
         regularized_wedge(1.0, rng.uniform01(), rng.uniform01() * 0.5 * pi);
     ankerl::nanobench::doNotOptimizeAway(result);

--- a/benchmarks/details.cpp
+++ b/benchmarks/details.cpp
@@ -19,9 +19,10 @@
  */
 
 #include <doctest/doctest.h>
-#include <nanobench.h>
 
 #include "overlap/overlap.hpp"
+
+#include "common.hpp"
 
 TEST_CASE("NormalNewell") {
   using namespace overlap::detail;
@@ -35,33 +36,19 @@ TEST_CASE("NormalNewell") {
       (Scalar{1} / Scalar{3}) *
       std::accumulate(points.begin(), points.end(), Vector::Zero().eval());
 
-  auto log = std::ofstream{"normal_newell.json"};
-  ankerl::nanobench::Bench()
-      .title("normal_newell")
-      .run("normal_newell",
-           [&]() {
-             const auto normal =
-                 normal_newell(points.begin(), points.end(), center);
-             ankerl::nanobench::doNotOptimizeAway(normal);
-           })
-      .render(ankerl::nanobench::templates::pyperf(), log);
+  create_benchmark("normal_newell", [&]() {
+    const auto normal = normal_newell(points.begin(), points.end(), center);
+    ankerl::nanobench::doNotOptimizeAway(normal);
+  });
 }
 
 TEST_CASE("RegularizedWedge") {
   using namespace overlap::detail;
 
-  auto log = std::ofstream{"regularized_wedge.json"};
   auto rng = ankerl::nanobench::Rng{};
-  ankerl::nanobench::Bench()
-      .title("regularized_wedge")
-      .run("regularized_wedge",
-           [&]() {
-             const auto result = regularized_wedge(1.0, rng.uniform01(),
-                                                   rng.uniform01() * 0.5 * pi);
-
-             ankerl::nanobench::doNotOptimizeAway(result);
-           })
-      .doNotOptimizeAway(rng)
-      .render(ankerl::nanobench::templates::pyperf(), log);
-  ;
+  create_benchmark("normal_newell", [&]() {
+    const auto result =
+        regularized_wedge(1.0, rng.uniform01(), rng.uniform01() * 0.5 * pi);
+    ankerl::nanobench::doNotOptimizeAway(result);
+  }).doNotOptimizeAway(rng);
 }

--- a/benchmarks/hex_overlap.cpp
+++ b/benchmarks/hex_overlap.cpp
@@ -24,10 +24,8 @@
 
 #include "common.hpp"
 
-TEST_CASE("HexOverlapVolume") {
+TEST_SUITE("HexOverlap") {
   using namespace overlap;
-
-  const auto sphere = Sphere{Vector::Zero(), 1.5};
 
   // clang-format off
   const auto hex = Hexahedron{{{
@@ -36,26 +34,21 @@ TEST_CASE("HexOverlapVolume") {
   }}};
   // clang-format on
 
-  create_benchmark("hex_overlap_volume", [&]() {
-    const auto result = overlap_volume(sphere, hex);
-    ankerl::nanobench::doNotOptimizeAway(result);
-  });
-}
+  TEST_CASE("HexOverlapVolume") {
+    const auto sphere = Sphere{Vector::Zero(), 1.5};
 
-TEST_CASE("HexOverlapVolumeAABB") {
-  using namespace overlap;
+    create_benchmark("hex_overlap_volume", [&]() {
+      const auto result = overlap_volume(sphere, hex);
+      ankerl::nanobench::doNotOptimizeAway(result);
+    });
+  }
 
-  const auto sphere = Sphere{Vector{5, 0, 0}, 1};
+  TEST_CASE("HexOverlapVolumeAABB") {
+    const auto sphere = Sphere{Vector{5, 0, 0}, 1};
 
-  // clang-format off
-  const auto hex = Hexahedron{{{
-      {-1, -1, -1}, {1, -1, -1}, {1, 1, -1}, {-1, 1, -1},
-      {-1, -1,  1}, {1, -1,  1}, {1, 1,  1}, {-1, 1,  1},
-  }}};
-  // clang-format on
-
-  create_benchmark("hex_overlap_volume_aabb", [&]() {
-    const auto result = overlap_volume(sphere, hex);
-    ankerl::nanobench::doNotOptimizeAway(result);
-  });
+    create_benchmark("hex_overlap_volume_aabb", [&]() {
+      const auto result = overlap_volume(sphere, hex);
+      ankerl::nanobench::doNotOptimizeAway(result);
+    });
+  }
 }

--- a/benchmarks/tet_overlap.cpp
+++ b/benchmarks/tet_overlap.cpp
@@ -2,7 +2,7 @@
  * Exact calculation of the overlap volume of spheres and mesh elements.
  * http://dx.doi.org/10.1016/j.jcp.2016.02.003
  *
- * Copyright (C) 2022 Severin Strobl <severin.strobl@fau.de>
+ * Copyright (C) 2023 Severin Strobl <severin.strobl@fau.de>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,38 +24,42 @@
 
 #include "common.hpp"
 
-TEST_CASE("HexOverlapVolume") {
+TEST_CASE("TetOverlapVolume") {
   using namespace overlap;
 
-  const auto sphere = Sphere{Vector::Zero(), 1.5};
+  const auto sphere = Sphere{Vector::Zero(), 0.5};
+
+  const auto sqrt3 = std::sqrt(Scalar{3});
+  const auto sqrt6 = std::sqrt(Scalar{6});
 
   // clang-format off
-  const auto hex = Hexahedron{{{
-      {-1, -1, -1}, {1, -1, -1}, {1, 1, -1}, {-1, 1, -1},
-      {-1, -1,  1}, {1, -1,  1}, {1, 1,  1}, {-1, 1,  1},
-  }}};
+  const auto tet = Tetrahedron{{{
+    {-sqrt3 / 6.0, -1.0 / 2.0, 0}, {sqrt3 / 3.0, 0, 0},
+    {-sqrt3 / 6.0, +1.0 / 2.0, 0}, {0, 0, sqrt6 / 3.0}}}};
   // clang-format on
 
-  create_benchmark("hex_overlap_volume", [&]() {
-    const auto result = overlap_volume(sphere, hex);
+  create_benchmark("tet_overlap_volume", [&]() {
+    const auto result = overlap_volume(sphere, tet);
     ankerl::nanobench::doNotOptimizeAway(result);
   });
 }
 
-TEST_CASE("HexOverlapVolumeAABB") {
+TEST_CASE("TetOverlapVolumeAABB") {
   using namespace overlap;
 
-  const auto sphere = Sphere{Vector{5, 0, 0}, 1};
+  const auto sphere = Sphere{Vector{2, 0, 0}, 0.5};
+
+  const auto sqrt3 = std::sqrt(Scalar{3});
+  const auto sqrt6 = std::sqrt(Scalar{6});
 
   // clang-format off
-  const auto hex = Hexahedron{{{
-      {-1, -1, -1}, {1, -1, -1}, {1, 1, -1}, {-1, 1, -1},
-      {-1, -1,  1}, {1, -1,  1}, {1, 1,  1}, {-1, 1,  1},
-  }}};
+  const auto tet = Tetrahedron{{{
+    {-sqrt3 / 6.0, -1.0 / 2.0, 0}, {sqrt3 / 3.0, 0, 0},
+    {-sqrt3 / 6.0, +1.0 / 2.0, 0}, {0, 0, sqrt6 / 3.0}}}};
   // clang-format on
 
-  create_benchmark("hex_overlap_volume_aabb", [&]() {
-    const auto result = overlap_volume(sphere, hex);
+  create_benchmark("tet_overlap_volume_aabb", [&]() {
+    const auto result = overlap_volume(sphere, tet);
     ankerl::nanobench::doNotOptimizeAway(result);
   });
 }

--- a/benchmarks/tet_overlap.cpp
+++ b/benchmarks/tet_overlap.cpp
@@ -24,10 +24,8 @@
 
 #include "common.hpp"
 
-TEST_CASE("TetOverlapVolume") {
+TEST_SUITE("TetOverlap") {
   using namespace overlap;
-
-  const auto sphere = Sphere{Vector::Zero(), 0.5};
 
   const auto sqrt3 = std::sqrt(Scalar{3});
   const auto sqrt6 = std::sqrt(Scalar{6});
@@ -38,28 +36,21 @@ TEST_CASE("TetOverlapVolume") {
     {-sqrt3 / 6.0, +1.0 / 2.0, 0}, {0, 0, sqrt6 / 3.0}}}};
   // clang-format on
 
-  create_benchmark("tet_overlap_volume", [&]() {
-    const auto result = overlap_volume(sphere, tet);
-    ankerl::nanobench::doNotOptimizeAway(result);
-  });
-}
+  TEST_CASE("TetOverlapVolume") {
+    const auto sphere = Sphere{Vector::Zero(), 0.5};
 
-TEST_CASE("TetOverlapVolumeAABB") {
-  using namespace overlap;
+    create_benchmark("tet_overlap_volume", [&]() {
+      const auto result = overlap_volume(sphere, tet);
+      ankerl::nanobench::doNotOptimizeAway(result);
+    });
+  }
 
-  const auto sphere = Sphere{Vector{2, 0, 0}, 0.5};
+  TEST_CASE("TetOverlapVolumeAABB") {
+    const auto sphere = Sphere{Vector{2, 0, 0}, 0.5};
 
-  const auto sqrt3 = std::sqrt(Scalar{3});
-  const auto sqrt6 = std::sqrt(Scalar{6});
-
-  // clang-format off
-  const auto tet = Tetrahedron{{{
-    {-sqrt3 / 6.0, -1.0 / 2.0, 0}, {sqrt3 / 3.0, 0, 0},
-    {-sqrt3 / 6.0, +1.0 / 2.0, 0}, {0, 0, sqrt6 / 3.0}}}};
-  // clang-format on
-
-  create_benchmark("tet_overlap_volume_aabb", [&]() {
-    const auto result = overlap_volume(sphere, tet);
-    ankerl::nanobench::doNotOptimizeAway(result);
-  });
+    create_benchmark("tet_overlap_volume_aabb", [&]() {
+      const auto result = overlap_volume(sphere, tet);
+      ankerl::nanobench::doNotOptimizeAway(result);
+    });
+  }
 }


### PR DESCRIPTION
Additional changes:
- factored out common benchmarking boilerplate
- increased the minimum number of iterations to improve stats