### PR TITLE
Enable dependabot also for development branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
+  # master branch
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "master"
+  # development branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"


### PR DESCRIPTION
In addition to the master branch, _dependabot_ should also keep the GitHub actions in the development branch up to date.