### PR TITLE
feat: switch from scikit-build to scikit-build-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,22 @@
-[build-system]
-requires = [
-  "cmake>=3.18",
-  "ninja; platform_system!='Windows'",
-  "scikit-build>=0.15.0",
-  "setuptools>=42",
-  "wheel",
-]
+[project]
+name = "overlap"
+version = "0.2.0-dev"
+requires-python = ">=3.7"
+dependencies = ["numpy"]
 
-build-backend = "setuptools.build_meta"
+[project.optional-dependencies]
+test = ["pytest >=6.0"]
+
+[build-system]
+requires = ["scikit-build-core"]
+
+build-backend = "scikit_build_core.build"
+
+[tool.scikit-build]
+cmake.version = ">=3.18"
 
 [tool.pytest.ini_options]
-minversion = "6.0"
-testpaths = [
-  "tests/python",
-]
+testpaths = ["tests/python"]
 
 [tool.cibuildwheel]
 test-requires = "pytest"

--- a/python/overlap/CMakeLists.txt
+++ b/python/overlap/CMakeLists.txt
@@ -25,14 +25,12 @@ set(package_name "overlap")
 pybind11_add_module(${package_name}_python MODULE ${package_name}.cpp)
 
 set_target_properties(
-  ${package_name}_python PROPERTIES OUTPUT_NAME _${package_name}
+  ${package_name}_python PROPERTIES OUTPUT_NAME ${package_name}
 )
 
 target_link_libraries(
   ${package_name}_python PRIVATE ${package_name}::headers Eigen3::Eigen
 )
-
-file(COPY "__init__.py" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 if(NOT SKBUILD)
   include(GNUInstallDirs)
@@ -44,10 +42,6 @@ if(NOT SKBUILD)
 
   install(TARGETS ${package_name}_python
           LIBRARY DESTINATION ${python_install_dir} COMPONENT python
-  )
-
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"
-          DESTINATION ${python_install_dir}
   )
 else()
   install(TARGETS ${package_name}_python LIBRARY DESTINATION .)

--- a/python/overlap/__init__.py
+++ b/python/overlap/__init__.py
@@ -1,1 +1,0 @@
-from ._overlap import *

--- a/python/overlap/overlap.cpp
+++ b/python/overlap/overlap.cpp
@@ -97,7 +97,7 @@ void createBindings(py::module& m) {
             .c_str());
 }
 
-PYBIND11_MODULE(_overlap, m) {
+PYBIND11_MODULE(overlap, m) {
   m.doc() = R"pbdoc(
         Pybind11 example plugin
         -----------------------

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,0 @@
-from skbuild import setup
-
-setup(
-    packages=['overlap'],
-    package_dir={'': 'python'},
-    cmake_install_dir='python/overlap',
-)


### PR DESCRIPTION
The modern _scikit-build-core_ provides a number of improvements over the older _scikit-build_. Apart from full support for _pyproject.toml_, editable installs work out of the box. The handling of build requirements is greatly improved, as well as the detection of the Python environment using _CMake_.