### PR TITLE
ci: update Python versions

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Added Python 3.11 and 3.12 while removing the end-of-life versions 3.6 and 3.7 in the CI pipeline.