### PR TITLE
ci: bump Codecov to version 4 and inherit secret

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
     name: Code coverage
     needs: [cpp]
     uses: ./.github/workflows/coverage.yaml
+    secrets: inherit
 
   static_analysis:
     name: Static analysis

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -42,7 +42,7 @@ jobs:
             -e ../third_party/ -e ../tests/src
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./build/coverage.xml
           fail_ci_if_error: true


### PR DESCRIPTION
This should avoid the rate limiting issues stemming from using the shared token instead of the project's own token.