### PR TITLE
fix: consider length scale in normalization

### DIFF
--- a/include/overlap/overlap.hpp
+++ b/include/overlap/overlap.hpp
@@ -63,8 +63,9 @@ auto normal_newell(Iterator first, Iterator last, const Vector& center)
         (*(first + i) - center).cross(*(first + ((i + 1) % count)) - center);
   }
 
+  const auto scale = normal.cwiseAbs().maxCoeff();
   if (const auto length = normal.stableNorm();
-      length > std::numeric_limits<Scalar>::epsilon()) {
+      length > scale * std::numeric_limits<Scalar>::epsilon()) {
     return normal / length;
   }
 

--- a/tests/src/test_normal_newell.cpp
+++ b/tests/src/test_normal_newell.cpp
@@ -67,7 +67,12 @@ TEST_SUITE("NormalNewell") {
     const auto normal =
         overlap::detail::normal_newell(points.begin(), points.end(), center);
 
-    REQUIRE_MESSAGE(normal.norm() < std::numeric_limits<Scalar>::epsilon(),
-                    format_msg(normal, Vector::Zero()));
+    REQUIRE_MESSAGE((normal.norm() < std::numeric_limits<Scalar>::epsilon() ||
+                     normal == Vector::UnitZ()),
+                    format_msg(normal, Vector::Zero()).append([]() {
+                      std::stringstream strm;
+                      strm << " or [" << Vector::UnitZ().transpose() << "]";
+                      return strm.str();
+                    }()));
   }
 }

--- a/tests/src/test_sphere_tet_overlap_edgecases.cpp
+++ b/tests/src/test_sphere_tet_overlap_edgecases.cpp
@@ -57,4 +57,19 @@ TEST_SUITE("SphereTetOverlap") {
             Approx(overlapCalcTets4).epsilon(epsilon * spheres[idx].volume));
     }
   }
+
+  TEST_CASE("#96") {
+    const auto center = Vector{1.7553357e-06, 4.2232066e-06, 5.8329073e-07};
+    const auto sphere = Sphere{center, 20e-9};
+
+    const auto vertices = std::array<Vector, 4>{
+        {{1.7503302395906002e-06, 4.2330364312997e-06, 5.961778422123901e-07},
+         {1.7438173901207002e-06, 4.222375361573301e-06, 5.9263766042144e-07},
+         {1.7394539738699001e-06, 4.2382759184772e-06, 6.009593818316999e-07},
+         {1.7544257028301e-06, 4.2350646020068004e-06, 5.840237397166e-07}}};
+
+    const auto tet = Tetrahedron{vertices};
+
+    CHECK(overlap_volume(sphere, tet) >= 0.0);
+  }
 }


### PR DESCRIPTION
When examining the length of the normal vector obtained using Newell's method prior to the actual normalization, the length scale has to be taken into account.

Fixes: #96