### PR TITLE
fix: edge case of general spherical wedge beyond sphere

### DIFF
--- a/include/overlap/overlap.hpp
+++ b/include/overlap/overlap.hpp
@@ -1200,6 +1200,11 @@ inline auto general_wedge(const Sphere& s, const Plane& p0, const Plane& p1,
     return spherical_wedge<Dim>(s, pi - detail::angle(p0.normal, p1.normal));
   }
 
+  if (dist >= s.radius) {
+    // intersection of the two planes (numerically) on the surface of the sphere
+    return Scalar{0};
+  }
+
   const auto s0 = d.dot(p0.normal);
   const auto s1 = d.dot(p1.normal);
 

--- a/tests/src/test_sphere_tet_overlap_edgecases.cpp
+++ b/tests/src/test_sphere_tet_overlap_edgecases.cpp
@@ -72,4 +72,18 @@ TEST_SUITE("SphereTetOverlap") {
 
     CHECK(overlap_volume(sphere, tet) >= 0.0);
   }
+
+  TEST_CASE("#104") {
+    const auto center = Vector{5.009999999999999e-07, 5.2e-07, 5e-7};
+    const auto sphere = Sphere{center, 20e-9};
+
+    const auto vertices = std::array<Vector, 4>{{{5e-7, 1e-6, 5e-7},
+                                                 {1e-6, 5e-7, 5e-7},
+                                                 {0, 5e-7, 5e-7},
+                                                 {5e-7, 5e-7, 0}}};
+
+    const auto tet = Tetrahedron{vertices};
+
+    CHECK(overlap_volume(sphere, tet) == Approx(0.5 * sphere.volume));
+  }
 }


### PR DESCRIPTION
In case the line formed by the intersection  of the two planes forming the
general wedge is tangential to (or numerically even beyond) the surface of the
sphere, the volume/area is zero.

---
Fixes: #104